### PR TITLE
Set eol = lf for .tpl files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh text eol=lf
+*.tpl text eol=lf


### PR DESCRIPTION
I was having a diferent behavior when executing the terraform plan because my pc was changing the eols of the `doppler.tpl` file to CRLF.
So I'm adding this change to specify the corresponding eol for such files.